### PR TITLE
Disable interrupts for longer led strips

### DIFF
--- a/LED_Synch_Mesh_Combined_08_Instructable.ino
+++ b/LED_Synch_Mesh_Combined_08_Instructable.ino
@@ -12,6 +12,8 @@
  *
  */
 
+// Disable interrupts allowing longer led strips without flicker.  Mesh still settles nearly as fast
+#define FASTLED_ALLOW_INTERRUPTS 0
 // LED Setup - must come before the painlessMesh so CRGB can be used as a return type
 #include <FastLED.h>
 // How many leds in your strip?


### PR DESCRIPTION
Preventing fastled from allowing the painless mesh library to interrupt it lets longer led strips work without flickering.   Tested with 144 leds.  The mesh still seems to settle nearly as fast.